### PR TITLE
Fix auto-migration order in db tables + minor fix

### DIFF
--- a/T1-G11/applicazione/manvsclass/src/main/java/com/groom/manvsclass/model/filesystem/RobotUtil.java
+++ b/T1-G11/applicazione/manvsclass/src/main/java/com/groom/manvsclass/model/filesystem/RobotUtil.java
@@ -11,7 +11,6 @@ import java.io.FileInputStream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipInputStream;
-import java.io.ObjectInputFilter.Config;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/T4-G18/main.go
+++ b/T4-G18/main.go
@@ -94,13 +94,13 @@ func run(ctx context.Context, c Configuration) error {
 	}
 
 	err = db.AutoMigrate(
+		&model.ScalataGame{},
 		&model.Game{},
 		&model.Round{},
 		&model.Player{},
 		&model.Turn{},
 		&model.Metadata{},
 		&model.PlayerGame{},
-		&model.ScalataGame{},
 		&model.Robot{})
 
 	if err != nil {


### PR DESCRIPTION
This pull request fixes the auto-migration order in the database tables. Previously, the order was incorrect, causing issues with tables creation. This PR ensures that the tables are auto-migrated in the correct order, resolving the problem.

Also, it removes an unnecessary dependancy.