### PR TITLE
Fix Generatore Evosuite

### DIFF
--- a/T0/EvosuiteGenerator/generate.sh
+++ b/T0/EvosuiteGenerator/generate.sh
@@ -45,6 +45,21 @@ cat  >>pom.txt << EOF
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>
 
 


### PR DESCRIPTION
- Fissato Java 8 nel pom come versione di Java da usare per compilare la classe passata per la generazione
